### PR TITLE
Treat empty proxy URL as good as no proxy URL

### DIFF
--- a/lib/rip_manager.c
+++ b/lib/rip_manager.c
@@ -367,7 +367,7 @@ start_ripping (RIP_MANAGER_INFO* rmi)
        check the environment variable */
     if (!pproxy) {
 	char const *env_http_proxy = getenv ("http_proxy");
-	if (env_http_proxy) {
+	if (env_http_proxy && env_http_proxy[0] != '\0') {
 	    pproxy = env_http_proxy;
 	    debug_printf ("Getting proxy from $http_proxy: %s\n", pproxy);
 	}


### PR DESCRIPTION
For example, when a user has this in bashrc:

    export http_proxy=

the function `getenv()` returns an empty string of length 0 (not a NULL
pointer). This patch treats this behavior as if `http_proxy` was not
set at all (`unset http_proxy`)

Without this patch, the user sees a misleading error msg:

    Connecting...
    
    error -3 [SR_ERROR_INVALID_URL]
    bye..
    shutting down
